### PR TITLE
Ajustes Pacientes

### DIFF
--- a/app/gerente/profesional/ProfesionalForm.tsx
+++ b/app/gerente/profesional/ProfesionalForm.tsx
@@ -28,8 +28,7 @@ export default function ProfesionalForm({
 }: Props) {
   const especialidades = useQuery(api.especialidades.listar);
   const obrasSociales = useQuery(api.obrasSociales.listar);
-
-  if (!especialidades || !obrasSociales) return <p className="text-gray-500">Cargando datos...</p>;
+  const isLoading = !especialidades || !obrasSociales;
 
   const [nombre, setNombre] = useState(initialData?.nombre ?? "");
   const [dni, setDni] = useState(initialData?.dni ?? "");
@@ -43,6 +42,8 @@ export default function ProfesionalForm({
     initialData?.obrasSociales ?? []
   );
   const [estado, setEstado] = useState<"Activo" | "Inactivo">(initialData?.estado ?? "Activo");
+
+  if (isLoading) return <p className="text-gray-500">Cargando datos...</p>;
 
   const handleObraSocialChange = (id: Id<"obrasSociales">) => {
     setObrasSeleccionadas(prev => (prev.includes(id) ? prev.filter(os => os !== id) : [...prev, id]));

--- a/app/recepcionista/pacientes/_components/obras-sociales-dropdown.tsx
+++ b/app/recepcionista/pacientes/_components/obras-sociales-dropdown.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Id } from "@/convex/_generated/dataModel";
+import { getObraSocialBadgeClass } from "../../_components/obra-social-badge";
 
 type ObrasSocial = {
   _id: Id<"obrasSociales">;
@@ -55,10 +56,7 @@ export function ObrasSocialesDropdown({
           {selectedNames.length > 0 ? (
             <div className="flex flex-wrap gap-1.5">
               {selectedNames.map((name, i) => (
-                <span
-                  key={i}
-                  className="inline-block px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-700 border border-green-200"
-                >
+                <span key={`${name}-${i}`} className={getObraSocialBadgeClass(name)}>
                   {name}
                 </span>
               ))}

--- a/app/recepcionista/pacientes/_components/pacientes-header.tsx
+++ b/app/recepcionista/pacientes/_components/pacientes-header.tsx
@@ -14,13 +14,10 @@ export function PacientesHeader({ onCreate, disableCreate = false }: PacientesHe
                 <div className="flex items-center gap-3 mb-6">
           <div className="w-1.5 h-8 bg-gradient-to-b from-green-500 to-emerald-500 rounded-full"></div>
           <div>
-            <h1 className="text-3xl font-bold text-gray-900">Gestión de Profesionales</h1>
-            <p className="text-gray-600 mt-1">Administra los profesionales de tu institución</p>
+            <h1 className="text-3xl font-bold text-gray-900">Gestión de Pacientes</h1>
+            <p className="text-gray-600 mt-1">Administra la información de todos los pacientes registrados</p>
           </div>
         </div>
-        <p className="text-gray-600 text-base md:ml-5">
-          Administra la información de todos los pacientes registrados
-        </p>
       </div>
       <button
         onClick={onCreate}

--- a/app/recepcionista/pacientes/_components/pacientes-header.tsx
+++ b/app/recepcionista/pacientes/_components/pacientes-header.tsx
@@ -11,9 +11,12 @@ export function PacientesHeader({ onCreate, disableCreate = false }: PacientesHe
   return (
     <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
       <div>
-        <div className="flex items-center gap-3 mb-2">
+                <div className="flex items-center gap-3 mb-6">
           <div className="w-1.5 h-8 bg-gradient-to-b from-green-500 to-emerald-500 rounded-full"></div>
-          <h1 className="text-3xl font-bold text-gray-900">Gestión de Pacientes</h1>
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Gestión de Profesionales</h1>
+            <p className="text-gray-600 mt-1">Administra los profesionales de tu institución</p>
+          </div>
         </div>
         <p className="text-gray-600 text-base md:ml-5">
           Administra la información de todos los pacientes registrados

--- a/app/recepcionista/pacientes/_components/pacientes-obras-filter.tsx
+++ b/app/recepcionista/pacientes/_components/pacientes-obras-filter.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Id } from "@/convex/_generated/dataModel";
+import { getObraSocialBadgeClass } from "../../_components/obra-social-badge";
+
+type ObraSocial = {
+  _id: Id<"obrasSociales">;
+  nombre: string;
+};
+
+type PacientesObrasFilterProps = {
+  obrasSociales: ObraSocial[];
+  selectedIds: Id<"obrasSociales">[];
+  onChange: (ids: Id<"obrasSociales">[]) => void;
+  disabled?: boolean;
+};
+
+export function PacientesObrasFilter({
+  obrasSociales,
+  selectedIds,
+  onChange,
+  disabled = false,
+}: PacientesObrasFilterProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const toggleId = (id: Id<"obrasSociales">) => {
+    onChange(
+      selectedIds.includes(id)
+        ? selectedIds.filter((current) => current !== id)
+        : [...selectedIds, id]
+    );
+  };
+
+  const clearFilters = () => {
+    onChange([]);
+  };
+
+  const selectedNames = obrasSociales
+    .filter((os) => selectedIds.includes(os._id))
+    .map((os) => os.nombre);
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <div className="relative">
+        <button
+          ref={buttonRef}
+          type="button"
+          disabled={disabled}
+          onClick={() => !disabled && setIsOpen((prev) => !prev)}
+          className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:border-gray-300 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Filtrar por obra social
+          <span className={`text-xs font-semibold ${selectedIds.length ? "text-green-600" : "text-gray-400"}`}>
+            {selectedIds.length ? `${selectedIds.length} seleccionadas` : "Todas"}
+          </span>
+        </button>
+
+        {isOpen && (
+          <div
+            ref={menuRef}
+            className="absolute left-0 z-20 mt-2 w-64 rounded-xl border border-gray-200 bg-white p-3 shadow-xl"
+          >
+            <div className="mb-2 flex items-center justify-between">
+              <p className="text-sm font-semibold text-gray-700">Obras sociales</p>
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="text-xs font-medium text-green-600 hover:text-green-700"
+              >
+                Limpiar
+              </button>
+            </div>
+            <div className="max-h-56 space-y-2 overflow-y-auto pr-1">
+              {obrasSociales.length ? (
+                obrasSociales.map((os) => (
+                  <label key={os._id} className="flex items-center gap-2 text-sm text-gray-700">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+                      checked={selectedIds.includes(os._id)}
+                      onChange={() => toggleId(os._id)}
+                    />
+                    <span className="truncate">{os.nombre}</span>
+                  </label>
+                ))
+              ) : (
+                <p className="text-sm text-gray-500">No hay obras sociales disponibles.</p>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {selectedNames.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {selectedNames.map((nombre, index) => (
+            <span
+              key={`${nombre}-${index}`}
+              className={getObraSocialBadgeClass(nombre)}
+            >
+              {nombre}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/recepcionista/pacientes/page.tsx
+++ b/app/recepcionista/pacientes/page.tsx
@@ -195,10 +195,15 @@ const sanitizeForm = (form: PacienteFormValues) => ({
         {totalPages > 1 && (
           <div className="px-6 pb-10">
             <div className="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-sm text-gray-600">
-                Mostrando {filteredPacientes.length === 0 ? 0 : (currentPage - 1) * pageSize + 1} -
-                {Math.min(currentPage * pageSize, filteredPacientes.length)} de {filteredPacientes.length} pacientes
-              </p>
+              <div className="space-y-1">
+                <p className="text-sm text-gray-600">
+                  Mostrando {filteredPacientes.length === 0 ? 0 : (currentPage - 1) * pageSize + 1} -
+                  {Math.min(currentPage * pageSize, filteredPacientes.length)} de {filteredPacientes.length} pacientes
+                </p>
+                <p className="text-xs font-medium text-gray-500">
+                  Página {currentPage} de {totalPages}
+                </p>
+              </div>
               <div className="flex flex-wrap items-center gap-2">
                 <button
                   onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}

--- a/app/recepcionista/pacientes/page.tsx
+++ b/app/recepcionista/pacientes/page.tsx
@@ -10,6 +10,7 @@ import { useDebouncedValue } from "@/hooks/use-debounce";
 import { PacientesHeader } from "./_components/pacientes-header";
 import { PacientesSearchBar } from "./_components/pacientes-search";
 import { PacientesTable } from "./_components/pacientes-table";
+import { PacientesObrasFilter } from "./_components/pacientes-obras-filter";
 import { PacienteForm, PacienteFormValues } from "./_components/paciente-form";
 import { ModalContainer } from "../_components/modal-container";
 import { ConfirmDialog } from "../_components/confirm-dialog";
@@ -20,6 +21,8 @@ export default function PacientesPage() {
   const debouncedSearch = useDebouncedValue(search, 250);
   const [seleccionado, setSeleccionado] = useState<PacienteRecord | null>(null);
   const [modo, setModo] = useState<"editar" | "crear" | "eliminar" | null>(null);
+  const [obrasFilter, setObrasFilter] = useState<Id<"obrasSociales">[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
   const router = useRouter();
 
   const pacientesConvex = useQuery(api.pacientes.listar, {}) as PacienteRecord[] | undefined;
@@ -43,7 +46,7 @@ export default function PacientesPage() {
     const base = (pacientesConvex ?? prevPacientesRef.current) || [];
     const lista = Array.isArray(base) ? (base as PacienteRecord[]) : [];
     const termino = debouncedSearch.trim();
-    if (!termino) return lista;
+    if (!termino && obrasFilter.length === 0) return lista;
 
     const terminoNormalizado = termino.toLowerCase();
     const coincide = (valor?: string | number | null) => {
@@ -52,16 +55,33 @@ export default function PacientesPage() {
       return comoTexto.toLowerCase().includes(terminoNormalizado);
     };
 
-    return lista.filter((paciente) =>
-      coincide(paciente.nombreCompleto) ||
-      coincide(paciente.dni) ||
-      coincide(paciente.email) ||
-      coincide(paciente.telefono) ||
-      coincide(paciente.fechaNacimiento) ||
-      coincide(paciente.genero) ||
-      (paciente.obrasSocialesNombres ?? []).some((nombre) => coincide(nombre))
-    );
-  }, [pacientesConvex, debouncedSearch]);
+    return lista.filter((paciente) => {
+      const coincideObras =
+        obrasFilter.length === 0 || obrasFilter.every((id) => (paciente.obrasSociales ?? []).includes(id));
+
+      if (!coincideObras) return false;
+
+      if (!termino) return true;
+
+      return (
+        coincide(paciente.nombreCompleto) ||
+        coincide(paciente.dni) ||
+        coincide(paciente.email) ||
+        coincide(paciente.telefono) ||
+        coincide(paciente.fechaNacimiento) ||
+        coincide(paciente.genero) ||
+        (paciente.obrasSocialesNombres ?? []).some((nombre) => coincide(nombre))
+      );
+    });
+  }, [pacientesConvex, debouncedSearch, obrasFilter]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [debouncedSearch, obrasFilter]);
+
+  const pageSize = 10;
+  const totalPages = Math.max(1, Math.ceil(filteredPacientes.length / pageSize));
+  const paginatedPacientes = filteredPacientes.slice((currentPage - 1) * pageSize, currentPage * pageSize);
 
   const crearPaciente = useMutation(api.pacientes.crear);
   const actualizarPaciente = useMutation(api.pacientes.actualizar);
@@ -111,8 +131,14 @@ const sanitizeForm = (form: PacienteFormValues) => ({
         <div className="w-full px-6 py-8 space-y-6">
           <PacientesHeader onCreate={() => setModo("crear")} disableCreate={isLoadingOS} />
           <PacientesSearchBar value={search} onChange={setSearch} isLoading={isLoadingPac} />
+          <PacientesObrasFilter
+            obrasSociales={obrasSociales}
+            selectedIds={obrasFilter}
+            onChange={setObrasFilter}
+            disabled={isLoadingOS}
+          />
           <PacientesTable
-            pacientes={filteredPacientes}
+            pacientes={paginatedPacientes}
             onView={handleVer}
             onEdit={(paciente) => {
               setSeleccionado(paciente);
@@ -164,6 +190,48 @@ const sanitizeForm = (form: PacienteFormValues) => ({
               />
             )}
           </ModalContainer>
+        )}
+
+        {totalPages > 1 && (
+          <div className="px-6 pb-10">
+            <div className="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-gray-600">
+                Mostrando {filteredPacientes.length === 0 ? 0 : (currentPage - 1) * pageSize + 1} -
+                {Math.min(currentPage * pageSize, filteredPacientes.length)} de {filteredPacientes.length} pacientes
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+                  disabled={currentPage === 1}
+                  className="rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Anterior
+                </button>
+                <div className="flex items-center gap-1">
+                  {Array.from({ length: totalPages }, (_, index) => index + 1).map((page) => (
+                    <button
+                      key={page}
+                      onClick={() => setCurrentPage(page)}
+                      className={`h-9 min-w-[36px] rounded-lg px-3 text-sm font-medium transition ${
+                        currentPage === page
+                          ? "bg-green-600 text-white shadow-sm"
+                          : "border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+                      }`}
+                    >
+                      {page}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+                  disabled={currentPage === totalPages}
+                  className="rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Siguiente
+                </button>
+              </div>
+            </div>
+          </div>
         )}
       </div>
     </PageWrapper>


### PR DESCRIPTION
Rediseñé la página de pacientes con layout tipo profesionales, acciones agrupadas en menú y formulario extraído; sumé filtro por texto y selección múltiple de obras sociales con badges coloreados.

Añadí paginación coherente con la estética (contador, botones Anterior/Siguiente) y saniticé creación/edición de pacientes con el nuevo campo género; la ficha detalla género y los badges se reutilizan en dashboard/formularios.

Refactoricé Convex (schema.ts, mutaciones) para soportar género, compatibilicé campos históricos de profesionales y ajusté el hook ProfesionalForm para evitar advertencias.

Implementé componentes compartidos (modal, confirm dialog, filtros) y moví useDebouncedValue a un hook reutilizable.

Agregue paginas a la tabla de  pacientes
